### PR TITLE
Add combined spectrogram preprocessing and dual-branch model

### DIFF
--- a/arousal/models/DeepSleepFinal.py
+++ b/arousal/models/DeepSleepFinal.py
@@ -1,0 +1,117 @@
+import torch
+import torch.nn as nn
+
+
+class SpectrogramEncoder(nn.Module):
+    """Encode spectrogram inputs while preserving the temporal resolution."""
+
+    def __init__(self, in_channels: int, hidden_channels: int = 128, dropout: float = 0.1):
+        super().__init__()
+        self.encoder = nn.Sequential(
+            nn.Conv2d(in_channels, 32, kernel_size=(3, 5), padding=(1, 2)),
+            nn.BatchNorm2d(32),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(kernel_size=(2, 1)),  # down-sample frequency only
+
+            nn.Conv2d(32, 64, kernel_size=(3, 3), padding=1),
+            nn.BatchNorm2d(64),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(kernel_size=(2, 1)),
+
+            nn.Conv2d(64, hidden_channels, kernel_size=(3, 3), padding=1),
+            nn.BatchNorm2d(hidden_channels),
+            nn.ReLU(inplace=True),
+            nn.Dropout2d(dropout),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (B, C_in, F, T)
+        features = self.encoder(x)
+        # Average frequency dimension -> (B, hidden_channels, T)
+        features = torch.mean(features, dim=2)
+        return features
+
+
+class TimeFeatureEncoder(nn.Module):
+    """Encode engineered time-domain features."""
+
+    def __init__(self, in_channels: int, hidden_channels: int = 64, dropout: float = 0.1):
+        super().__init__()
+        self.encoder = nn.Sequential(
+            nn.Conv1d(in_channels, 64, kernel_size=5, padding=2),
+            nn.BatchNorm1d(64),
+            nn.ReLU(inplace=True),
+            nn.Dropout(dropout),
+
+            nn.Conv1d(64, hidden_channels, kernel_size=5, padding=2),
+            nn.BatchNorm1d(hidden_channels),
+            nn.ReLU(inplace=True),
+            nn.Dropout(dropout),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (B, C_in, T)
+        return self.encoder(x)
+
+
+class DeepSleepFinal(nn.Module):
+    """Two-branch network that fuses spectral and time-domain evidence."""
+
+    def __init__(
+        self,
+        n_spectrogram_channels: int,
+        n_time_feature_channels: int,
+        spec_hidden: int = 128,
+        time_hidden: int = 64,
+        fusion_hidden: int = 160,
+        dropout: float = 0.2,
+    ):
+        super().__init__()
+        self.spec_encoder = SpectrogramEncoder(
+            in_channels=n_spectrogram_channels,
+            hidden_channels=spec_hidden,
+            dropout=dropout / 2,
+        )
+        self.time_encoder = TimeFeatureEncoder(
+            in_channels=n_time_feature_channels,
+            hidden_channels=time_hidden,
+            dropout=dropout / 2,
+        )
+
+        self.attention_gate = nn.Conv1d(time_hidden, spec_hidden, kernel_size=1)
+
+        self.fusion = nn.Sequential(
+            nn.Conv1d(spec_hidden + time_hidden, fusion_hidden, kernel_size=3, padding=1),
+            nn.BatchNorm1d(fusion_hidden),
+            nn.ReLU(inplace=True),
+            nn.Dropout(dropout),
+            nn.Conv1d(fusion_hidden, fusion_hidden, kernel_size=3, padding=1),
+            nn.BatchNorm1d(fusion_hidden),
+            nn.ReLU(inplace=True),
+            nn.Dropout(dropout),
+        )
+        self.classifier = nn.Conv1d(fusion_hidden, 1, kernel_size=1)
+
+    def forward(self, inputs, return_prob: bool = False):
+        if not isinstance(inputs, dict):
+            raise ValueError("DeepSleepFinal expects a dict with 'spectrogram' and 'time_features'.")
+
+        spec = inputs["spectrogram"]  # (B, C, F, T)
+        time_features = inputs["time_features"]  # (B, C, K, T)
+
+        batch_size, channels, feature_bins, time_bins = time_features.shape
+        time_features = time_features.reshape(batch_size, channels * feature_bins, time_bins)
+
+        spec_repr = self.spec_encoder(spec)
+        time_repr = self.time_encoder(time_features)
+
+        gate = torch.sigmoid(self.attention_gate(time_repr))
+        spec_repr = spec_repr * gate
+
+        fused = torch.cat([spec_repr, time_repr], dim=1)
+        fused = self.fusion(fused)
+        logits = self.classifier(fused).squeeze(1)
+
+        if return_prob:
+            return torch.sigmoid(logits)
+        return logits

--- a/arousal/models/__init__.py
+++ b/arousal/models/__init__.py
@@ -1,3 +1,4 @@
 from .DeepSleepSota import DeepSleepNetSota
 from .DeepSleepNet2 import DeepSleepNet2
 from .DeepSleepNet1 import DeepSleepNet1
+from .DeepSleepFinal import DeepSleepFinal

--- a/arousal/prep_spectrogram_combined.py
+++ b/arousal/prep_spectrogram_combined.py
@@ -1,0 +1,215 @@
+import warnings
+warnings.filterwarnings('ignore')
+
+import argparse
+import os
+import pickle
+from os.path import basename, join
+
+import numpy as np
+from scipy.signal import spectrogram, hilbert
+
+from utils.tools import load_edf_file, load_arousal_xml, create_arousal_labels
+
+
+def robust_scale(x: np.ndarray) -> np.ndarray:
+    median = np.median(x, axis=1, keepdims=True)
+    mad = np.median(np.abs(x - median), axis=1, keepdims=True) + 1e-9
+    return (x - median) / mad
+
+
+def make_spectrogram(data: np.ndarray, fs: int, nperseg: int, noverlap: int):
+    n_channels = data.shape[0]
+    specs = []
+    for ch in range(n_channels):
+        f, t, Sxx = spectrogram(
+            data[ch],
+            fs=fs,
+            window="hann",
+            nperseg=nperseg,
+            noverlap=noverlap,
+            nfft=nperseg,
+            scaling="density",
+            mode="psd",
+        )
+        Sxx = 10 * np.log10(Sxx + 1e-12)
+        specs.append(Sxx[None, ...])
+    spec = np.concatenate(specs, axis=0)
+    return spec.astype(np.float32), f, t
+
+
+def compute_time_features(data: np.ndarray, fs: int, times: np.ndarray, window_size: int):
+    n_channels, total_samples = data.shape
+    half_window = window_size // 2
+    n_windows = len(times)
+
+    feature_names = [
+        "mean",
+        "std",
+        "abs_mean",
+        "line_length",
+        "energy",
+        "hilbert_mean",
+        "hilbert_max",
+        "slope",
+    ]
+
+    features = np.zeros((n_channels, len(feature_names), n_windows), dtype=np.float32)
+
+    for t_idx, center_time in enumerate(times):
+        center_sample = int(round(center_time * fs))
+        start = max(center_sample - half_window, 0)
+        end = start + window_size
+        if end > total_samples:
+            end = total_samples
+            start = max(end - window_size, 0)
+
+        segment = data[:, start:end]
+        if segment.shape[1] < window_size:
+            pad = window_size - segment.shape[1]
+            segment = np.pad(segment, ((0, 0), (0, pad)), mode="edge")
+
+        abs_seg = np.abs(segment)
+        diff_seg = np.diff(segment, axis=1)
+        envelope = np.abs(hilbert(segment, axis=1))
+
+        features[:, 0, t_idx] = np.mean(segment, axis=1)
+        features[:, 1, t_idx] = np.std(segment, axis=1)
+        features[:, 2, t_idx] = np.mean(abs_seg, axis=1)
+        features[:, 3, t_idx] = np.mean(np.abs(diff_seg), axis=1)
+        features[:, 4, t_idx] = np.mean(segment ** 2, axis=1)
+        features[:, 5, t_idx] = np.mean(envelope, axis=1)
+        features[:, 6, t_idx] = np.max(envelope, axis=1)
+        features[:, 7, t_idx] = segment[:, -1] - segment[:, 0]
+
+    # Abrupt change descriptors based on first-order differences
+    change_features = []
+    change_names = []
+    for idx, name in enumerate(["abs_mean", "energy", "hilbert_mean"]):
+        series = features[:, feature_names.index(name), :]
+        delta = np.diff(series, prepend=series[:, :1], axis=1)
+        change_features.append(delta[:, None, :])
+        change_names.append(f"d_{name}")
+
+    if change_features:
+        change_matrix = np.concatenate(change_features, axis=1)
+        features = np.concatenate([features, change_matrix], axis=1)
+        feature_names.extend(change_names)
+
+    # Normalise per-channel for stability
+    mean = np.mean(features, axis=2, keepdims=True)
+    std = np.std(features, axis=2, keepdims=True)
+    std[std < 1e-6] = 1e-6
+    features = (features - mean) / std
+
+    return features.astype(np.float32), feature_names
+
+
+def map_label_to_spec_time(labels: np.ndarray, times: np.ndarray, fs: int, window_size: int):
+    half_window_sec = window_size / (2.0 * fs)
+    mapped = np.zeros(len(times), dtype=np.float32)
+
+    for idx, center_time in enumerate(times):
+        start_sec = center_time - half_window_sec
+        end_sec = center_time + half_window_sec
+        start = int(np.floor(start_sec * fs))
+        end = int(np.ceil(end_sec * fs))
+        start = max(start, 0)
+        end = min(end, len(labels))
+        if np.any(labels[start:end] == 1):
+            mapped[idx] = 1.0
+    return mapped
+
+
+def detect_artifact_mask(spec: np.ndarray, threshold: float = 1e-5):
+    per_channel_mask = np.all(spec < threshold, axis=1)
+    return np.any(per_channel_mask, axis=0).astype(np.uint8)
+
+
+def process_record(
+    edf_path: str,
+    xml_path: str,
+    save_dir: str,
+    fs: int,
+    nperseg: int,
+    noverlap: int,
+    do_filter: bool = False,
+):
+    filename = basename(edf_path).replace(".edf", ".pkl")
+    save_path = join(save_dir, filename)
+
+    raw = load_edf_file(edf_path, preload=True, resample=fs, do_filter=do_filter)
+    meas_date = raw.info["meas_date"]
+    data = raw.get_data()
+
+    data_norm = robust_scale(data)
+    events = load_arousal_xml(xml_path)
+    total_samples = data_norm.shape[1]
+    labels = create_arousal_labels(events, meas_date, total_samples, sfreq=fs)
+
+    spec, freqs, times = make_spectrogram(data_norm, fs=fs, nperseg=nperseg, noverlap=noverlap)
+    spec = (spec - np.mean(spec, axis=(1, 2), keepdims=True)) / (np.std(spec, axis=(1, 2), keepdims=True) + 1e-6)
+
+    time_features, feature_names = compute_time_features(data_norm, fs=fs, times=times, window_size=nperseg)
+    artifact_mask = detect_artifact_mask(spec)
+
+    mapped_labels = map_label_to_spec_time(labels, times, fs=fs, window_size=nperseg)
+
+    result = {
+        "spectrogram": spec.astype(np.float32),
+        "time_features": time_features.astype(np.float32),
+        "feature_names": feature_names,
+        "freqs": freqs.astype(np.float32),
+        "times": times.astype(np.float32),
+        "y": mapped_labels.astype(np.float32),
+        "artifact_mask": artifact_mask,
+    }
+
+    with open(save_path, "wb") as f:
+        pickle.dump(result, f)
+
+    return save_path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create combined spectrogram + time-domain features")
+    parser.add_argument("edf_dir", type=str, help="Directory with EDF files")
+    parser.add_argument("xml_dir", type=str, help="Directory with XML annotation files")
+    parser.add_argument("save_dir", type=str, help="Directory to save pickle files")
+    parser.add_argument("--sfreq", type=int, default=50)
+    parser.add_argument("--nperseg", type=int, default=100)
+    parser.add_argument("--noverlap", type=int, default=50)
+    parser.add_argument("--limit", type=int, default=-1, help="Process only first N files")
+    parser.add_argument("--do_filter", action="store_true")
+    args = parser.parse_args()
+
+    os.makedirs(args.save_dir, exist_ok=True)
+
+    edf_files = [f for f in sorted(os.listdir(args.edf_dir)) if f.lower().endswith(".edf")]
+    if args.limit > 0:
+        edf_files = edf_files[:args.limit]
+
+    for idx, edf_file in enumerate(edf_files):
+        edf_path = join(args.edf_dir, edf_file)
+        xml_name = edf_file.replace(".edf", "_AROUS.xml")
+        xml_path = join(args.xml_dir, xml_name)
+        if not os.path.exists(xml_path):
+            print(f"[Skip] Missing XML for {edf_file}")
+            continue
+        try:
+            output_path = process_record(
+                edf_path,
+                xml_path,
+                args.save_dir,
+                fs=args.sfreq,
+                nperseg=args.nperseg,
+                noverlap=args.noverlap,
+                do_filter=args.do_filter,
+            )
+            print(f"[{idx + 1}/{len(edf_files)}] Saved {output_path}")
+        except Exception as exc:
+            print(f"[Error] {edf_file}: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/arousal/train_deepsleep.py
+++ b/arousal/train_deepsleep.py
@@ -1,217 +1,252 @@
+import argparse
 import os
-import numpy as np
-import torch
 import pickle
 import random
-import datetime
-import torch.utils.tensorboard as tb
+from typing import Dict, List, Tuple
 
-from torch.utils.data import DataLoader
-from utils.datasets import OnTheFlyArousalDataset
-from utils.losses import *
-from utils.score2018 import *
-from models.DeepSleepNet2 import *
-from models.DeepSleepNet1 import *
-from models.DeepSleepSota import DeepSleepNetSota
-from utils.transforms import *
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from utils.losses import CustomBCEWithLogitsLoss, CustomAsymmetricLoss, BoundaryAwareAsymmetricLoss
+from utils.score2018 import Challenge2018ScoreVer2
+from models.DeepSleepFinal import DeepSleepFinal
 
 
-def str2bool(v):
-    if isinstance(v, bool):
-       return v
-    if v.lower() in ('yes', 'true', 't', 'y', '1', 'True'):
-        return True
-    elif v.lower() in ('no', 'false', 'f', 'n', '0', 'False'):
-        return False
-    else:
-        raise argparse.ArgumentTypeError('Boolean value expected.')
-    
-def eval_fn(model, loader, device, comp_score = True):
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
+
+class CombinedFeatureDataset(Dataset):
+    def __init__(self, file_paths: List[str]):
+        self.file_paths = file_paths
+
+    def __len__(self) -> int:
+        return len(self.file_paths)
+
+    def __getitem__(self, idx: int):
+        file_path = self.file_paths[idx]
+        with open(file_path, "rb") as f:
+            data = pickle.load(f)
+
+        spec = torch.from_numpy(data["spectrogram"]).float()
+        time_features = torch.from_numpy(data["time_features"]).float()
+        labels = torch.from_numpy(data["y"]).float()
+
+        record_id = os.path.splitext(os.path.basename(file_path))[0]
+        inputs = {"spectrogram": spec, "time_features": time_features}
+        return inputs, labels, record_id
+
+
+def combined_collate_fn(batch: List[Tuple[Dict[str, torch.Tensor], torch.Tensor, str]]):
+    max_time = max(item[0]["spectrogram"].shape[-1] for item in batch)
+    batch_size = len(batch)
+
+    spec_channels = batch[0][0]["spectrogram"].shape[0]
+    spec_freqs = batch[0][0]["spectrogram"].shape[1]
+    time_channels = batch[0][0]["time_features"].shape[0]
+    time_features = batch[0][0]["time_features"].shape[1]
+
+    spec_batch = torch.zeros(batch_size, spec_channels, spec_freqs, max_time)
+    time_batch = torch.zeros(batch_size, time_channels, time_features, max_time)
+    label_batch = torch.full((batch_size, max_time), -1.0)
+    record_ids = []
+
+    for idx, (inputs, labels, record_id) in enumerate(batch):
+        length = inputs["spectrogram"].shape[-1]
+        spec_batch[idx, :, :, :length] = inputs["spectrogram"]
+        time_batch[idx, :, :, :length] = inputs["time_features"]
+        label_batch[idx, :length] = labels
+        record_ids.append(record_id)
+
+    inputs = {"spectrogram": spec_batch, "time_features": time_batch}
+    return inputs, label_batch, record_ids
+
+
+def eval_fn(model, loader, device):
     model.eval()
-    
-    scores = Challenge2018ScoreVer2() if comp_score else None
-    
-    if comp_score:
-        criterion = CustomBCELoss().to(device)
-    else:
-        criterion = CustomBCEWithLogitsLoss().to(device)
-    
+    criterion = CustomBCEWithLogitsLoss().to(device)
+    scores = Challenge2018ScoreVer2()
+
+    loss_epoch_sum = 0.0
+    val_auroc = 0.0
+    val_auprc = 0.0
+    val_best_f1 = 0.0
+    val_best_thr = 0.0
+
     with torch.no_grad():
-        loss_epoch_sum = 0
-        val_auroc, val_auprc, best_f1, best_th = 0, 0, 0, 0
-        for x, y, idx in loader:          
-            x = x.to(device = device)
-            y = y.to(device = device)
+        for inputs, targets, record_ids in loader:
+            inputs = {k: v.to(device) for k, v in inputs.items()}
+            targets = targets.to(device)
 
-            # with torch.amp.autocast(device, enabled = torch.cuda.is_available() and not comp_score):
-            y_pred = model(x, comp_score)
-            # y_pred = torch.sigmoid(y_pred)
-            loss = criterion(y_pred, y)
-        
-            # compute AUROC/AUPRC score for each record in batch
-            if comp_score:
-                for i, single_idx in enumerate(idx):
-                    record_name = str(single_idx.item())
-                    y_target = y[i].view(-1).to('cpu')
-                    y_pred_i = y_pred[i].view(-1).to('cpu')
-                    y_pad_mask = y_target != -1
-                    scores.score_record(y_target[y_pad_mask], y_pred_i[y_pad_mask], record_name)
-                    auroc = scores.record_auroc(record_name)
-                    auprc = scores.record_auprc(record_name)
-                    f1 = scores.record_f1(record_name)
-                    th = scores.record_best_threshold(record_name)
-                    # print(f"Record{record_name}  AUROC: {auroc},  AUPRC: {auprc}")
-                    val_auroc += auroc
-                    val_auprc += auprc
-                    best_f1 += f1
-                    best_th += th
-
-
+            logits = model(inputs)
+            loss = criterion(logits, targets)
             loss_epoch_sum += float(loss.item())
-        
-        val_auroc /= len(loader.dataset)
-        val_auprc /= len(loader.dataset)
-        best_f1 /= len(loader.dataset)
-        best_th /= len(loader.dataset)
 
-        print(f"Best F1: {best_f1:.4f}, Best Threshold: {best_th:.4f}")
+            probs = torch.sigmoid(logits).cpu()
+            targets_cpu = targets.cpu()
 
-    return loss_epoch_sum/len(loader), val_auroc, val_auprc, best_th
+            for i, record_id in enumerate(record_ids):
+                y_target = targets_cpu[i]
+                y_pred = probs[i]
+                mask = y_target > -0.5
+                y_target = y_target[mask]
+                y_pred = y_pred[mask]
+                if len(y_target) == 0:
+                    continue
+                scores.score_record(y_target.numpy(), y_pred.numpy(), record_id)
+                val_auroc += scores.record_auroc(record_id)
+                val_auprc += scores.record_auprc(record_id)
+                val_best_f1 += scores.record_f1(record_id)
+                val_best_thr += scores.record_best_threshold(record_id)
+
+    num_records = len(loader.dataset)
+    if num_records > 0:
+        val_auroc /= num_records
+        val_auprc /= num_records
+        val_best_f1 /= num_records
+        val_best_thr /= num_records
+
+    mean_loss = loss_epoch_sum / max(len(loader), 1)
+    return mean_loss, val_auroc, val_auprc, val_best_f1, val_best_thr
 
 
-def load_labeled_data(file_paths, num_channels = 9):
-    data_list, labels = [], []
-    for file_path in file_paths:
-        with open(file_path, 'rb') as f:
-            d = pickle.load(f)
-            x, y = d['x'][:num_channels,:], d['y'].astype(np.int64)
-            data_list.append(x)
-            labels.append(y)
-
-    return data_list, labels
+def build_model(sample_batch: Dict[str, torch.Tensor]) -> DeepSleepFinal:
+    spec_channels = sample_batch["spectrogram"].shape[1]
+    time_feature_channels = sample_batch["time_features"].shape[1] * sample_batch["time_features"].shape[2]
+    model = DeepSleepFinal(
+        n_spectrogram_channels=spec_channels,
+        n_time_feature_channels=time_feature_channels,
+    )
+    return model
 
 
-if __name__ == '__main__':
-    import argparse
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--model', type=str, default='DeepSleepSota')
-    parser.add_argument('--gpu', type=int, default=0)
-    parser.add_argument('--num_channels', type=int, default=9)
-    parser.add_argument('--lr', type=float, default=1e-4)
-    parser.add_argument('--loss', type=str, default='asl')
-    parser.add_argument('--freq', type=int, default=50)
-    parser.add_argument('--batch_size', type=int, default=2)
-    parser.add_argument('--use_tb', type=str2bool, default=False)
-    parser.add_argument('--mix_db', type=str2bool, default=False)
-    parser.add_argument('--target_db', type=str, default='2', choices=['1', '2', 'mixed'])
-    parser.add_argument('--ver', type=int, default=3)
-    parser.add_argument('--noise_minmax', type=str, default='0.5_0.8')
-    parser.add_argument('--seed', type=int, default=42)
-    parser.add_argument('--tag', type=str, default='')
+def main():
+    parser = argparse.ArgumentParser(description="Train DeepSleepFinal with combined features")
+    parser.add_argument("--data_dir", type=str, default="./data/combined", help="Directory with combined pickle files")
+    parser.add_argument("--batch_size", type=int, default=2)
+    parser.add_argument("--num_workers", type=int, default=4)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--epochs", type=int, default=50)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--val_ratio", type=float, default=0.2)
+    parser.add_argument("--loss", type=str, choices=["bce", "asl", "ba_asl"], default="bce")
+    parser.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu")
+    parser.add_argument("--output_dir", type=str, default="./checkpoints")
+    parser.add_argument("--patience", type=int, default=20)
     args = parser.parse_args()
 
-    torch.manual_seed(args.seed)
-    np.random.seed(args.seed)
-    random.seed(args.seed)
-    torch.backends.cudnn.deterministic = True
-    torch.backends.cudnn.benchmark = False   
+    set_seed(args.seed)
+    os.makedirs(args.output_dir, exist_ok=True)
 
-    if args.mix_db:
-        dataset_dirs = [f"/home/honeynaps/data/dataset/PICKLE/AROUSAL_VER{args.ver}_{args.freq}_PAD",
-                        f"/home/honeynaps/data/dataset2/PICKLE/AROUSAL_VER{args.ver}_{args.freq}_PAD"]
+    file_paths = [
+        os.path.join(args.data_dir, f)
+        for f in sorted(os.listdir(args.data_dir))
+        if f.endswith(".pkl")
+    ]
+
+    if len(file_paths) == 0:
+        raise RuntimeError(f"No pickle files found in {args.data_dir}. Run prep_spectrogram_combined.py first.")
+
+    random.shuffle(file_paths)
+    split_idx = int(len(file_paths) * (1.0 - args.val_ratio))
+    train_files = file_paths[:split_idx]
+    val_files = file_paths[split_idx:]
+
+    if len(train_files) == 0 or len(val_files) == 0:
+        raise RuntimeError("Not enough data to create train/validation splits. Adjust --val_ratio or add more data.")
+
+    train_dataset = CombinedFeatureDataset(train_files)
+    val_dataset = CombinedFeatureDataset(val_files)
+
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=args.batch_size,
+        shuffle=True,
+        num_workers=args.num_workers,
+        collate_fn=combined_collate_fn,
+        drop_last=False,
+    )
+
+    val_loader = DataLoader(
+        val_dataset,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=args.num_workers,
+        collate_fn=combined_collate_fn,
+        drop_last=False,
+    )
+
+    sample_inputs, _, _ = next(iter(train_loader))
+    model = build_model(sample_inputs)
+    model = model.to(args.device)
+
+    if args.loss == "bce":
+        criterion = CustomBCEWithLogitsLoss().to(args.device)
+    elif args.loss == "asl":
+        criterion = CustomAsymmetricLoss().to(args.device)
     else:
-        db_option = ''
+        criterion = BoundaryAwareAsymmetricLoss().to(args.device)
 
-        if args.target_db == '2':
-            db_option = '2'
-        elif args.target_db == 'mixed':
-            db_option = '_mixed'
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr, weight_decay=1e-5)
 
-        dataset_dirs = [f"/home/honeynaps/data/dataset{db_option}/PICKLE/AROUSAL_VER{args.ver}_{args.freq}_PAD"]
+    best_val_auprc = 0.0
+    best_epoch = -1
+    patience_counter = 0
+    best_checkpoint_path = None
 
-    # Load labeled data files
-    labels_file_paths = []
-    for dataset_dir in dataset_dirs:
-        labels_file_paths.extend([os.path.join(dataset_dir, f) for f in os.listdir(dataset_dir) if f.endswith('.pkl')])
-
-    random.shuffle(labels_file_paths)
-    train_ratio = 0.8
-    split_index = int(train_ratio*len(labels_file_paths))
-    train_files = labels_file_paths[:split_index]
-    val_files = labels_file_paths[split_index:]
-
-    transforms = ["NormaliseAndAddRandNoise"]
-    model_in_channels = 3 if 'SelectOne' in transforms else args.num_channels
-    val_transforms = ["NormaliseOnly", "SelectOneEval"] if "SelectOne" in transforms else ["NormaliseOnly"]
-    tf_str = "_".join(transforms)
-
-    transforms = build_transforms(transforms, n_channels = args.num_channels, noise_minmax = args.noise_minmax)
-    val_transforms = build_transforms(val_transforms, n_channels = args.num_channels, noise_minmax = args.noise_minmax)
-    
-    train_dataset = OnTheFlyArousalDataset(train_files, args.num_channels, transforms=transforms)
-    val_dataset = OnTheFlyArousalDataset(val_files, args.num_channels, val_transforms)
-
-    mix_str = 'True' if args.mix_db else args.target_db
-    current_setting = f"{args.model}_FS{args.freq}_{args.loss}_CH{args.num_channels}_BS{args.batch_size}_{tf_str}_LR{args.lr}" + \
-                      f"_MIX{args.mix_db}_VER{args.ver}_NS_{args.noise_minmax}_{args.tag}"
-
-    tb_name = f'{str(datetime.datetime.now().strftime("%Y-%m-%d_%H:%M:%S"))}_{current_setting}'
-    if args.use_tb:
-        TB_WRITER = tb.SummaryWriter(f'/home/honeynaps/data/eis/arousalnet_r1/tensorboards/{tb_name}')
-
-    device = f'cuda:{args.gpu}' if torch.cuda.is_available() else 'cpu'
-
-    if args.model.lower() == 'deepsleep2':
-        model = DeepSleepNet2(in_channels=model_in_channels, linear=True).to(device)
-    else:
-        model = DeepSleepNetSota(n_channels=model_in_channels).to(device)
-
-    train_dataloader = DataLoader(train_dataset, batch_size=args.batch_size, shuffle=True, num_workers=4, drop_last=True, pin_memory=True)
-    val_dataloader = DataLoader(val_dataset, batch_size=args.batch_size, shuffle=False, num_workers=4, pin_memory=True)
-
-    if args.loss == 'bce':
-        criterion = CustomBCEWithLogitsLoss().to(device)
-    elif args.loss == 'asl':
-        criterion = CustomAsymmetricLoss().to(device)
-    elif args.loss == 'ba_asl':
-        criterion = BoundaryAwareAsymmetricLoss().to(device)
-    else:
-        criterion = dice_coef_loss
-
-    optimizer = torch.optim.Adam(model.parameters(), lr = args.lr, weight_decay = 1e-5)
-
-    num_epochs = 200
-    best_train_auprc, best_val_auprc = 0, 0
-
-    for epoch in range(num_epochs):
-        print(f"Epoch {epoch + 1}: {current_setting}")
+    for epoch in range(1, args.epochs + 1):
         model.train()
+        running_loss = 0.0
 
-        for i, (x, y, idx) in enumerate(train_dataloader):
+        for inputs, targets, _ in train_loader:
+            inputs = {k: v.to(args.device) for k, v in inputs.items()}
+            targets = targets.to(args.device)
+
             optimizer.zero_grad()
-            x, y = x.to(device), y.to(device)
-            y_pred = model(x)
-            loss = criterion(y_pred, y)
+            logits = model(inputs)
+            loss = criterion(logits, targets)
             loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=5.0)
             optimizer.step()
-            
-        train_loss, train_auroc, train_auprc, train_th = eval_fn(model, train_dataloader, device, comp_score = True)
-        print(f"Train loss: {train_loss:.4f}, AUROC: {train_auroc:.4f}, AUPRC: {train_auprc:.4f},")
 
-        if train_auprc > best_train_auprc:
-            best_train_auprc = train_auprc
+            running_loss += float(loss.item())
 
-        val_loss, val_auroc, val_auprc, val_th = eval_fn(model, val_dataloader, device, comp_score = True)
-        print(f"Validation loss: {val_loss:.4f}, AUROC: {val_auroc:.4f}, AUPRC: {val_auprc:.4f}")
+        train_loss = running_loss / max(len(train_loader), 1)
+        val_loss, val_auroc, val_auprc, val_f1, val_thr = eval_fn(model, val_loader, args.device)
 
-        print(f"Best Train AUPRC: {best_train_auprc:.4f} Best Val AUPRC: {best_val_auprc:.4f}")
-        print("=====================================================")
+        print(f"Epoch {epoch:03d} | Train Loss: {train_loss:.4f} | Val Loss: {val_loss:.4f} | "
+              f"Val AUROC: {val_auroc:.4f} | Val AUPRC: {val_auprc:.4f} | Val F1: {val_f1:.4f} | Val Th: {val_thr:.3f}")
 
-        if args.use_tb:
-            TB_WRITER.add_scalar('Loss/train', train_loss, epoch)
-            TB_WRITER.add_scalar('Loss/val', val_loss, epoch)
-            TB_WRITER.add_scalar('AUROC/train', train_auroc, epoch)
-            TB_WRITER.add_scalar('AUROC/val', val_auroc, epoch)
-            TB_WRITER.add_scalar('AUPRC/train', train_auprc, epoch)
-            TB_WRITER.add_scalar('AUPRC/val', val_auprc, epoch)
+        if val_auprc > best_val_auprc:
+            best_val_auprc = val_auprc
+            best_epoch = epoch
+            patience_counter = 0
+            best_checkpoint_path = os.path.join(args.output_dir, f"deepsleep_final_epoch{epoch:03d}.pt")
+            torch.save({
+                "epoch": epoch,
+                "model_state": model.state_dict(),
+                "optimizer_state": optimizer.state_dict(),
+                "val_auprc": val_auprc,
+                "val_auroc": val_auroc,
+                "val_f1": val_f1,
+                "val_thr": val_thr,
+            }, best_checkpoint_path)
+        else:
+            patience_counter += 1
+            if patience_counter >= args.patience:
+                print("Early stopping triggered.")
+                break
 
+    print(f"Best validation AUPRC: {best_val_auprc:.4f} at epoch {best_epoch}")
+    if best_checkpoint_path is not None:
+        print(f"Best model saved to {best_checkpoint_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add preprocessing pipeline that augments spectrograms with engineered amplitude and abrupt-change descriptors
- introduce DeepSleepFinal dual-branch model to fuse spectral and time-domain evidence
- refactor training script to consume the combined features and track challenge metrics while checkpointing the best model

## Testing
- `python arousal/train_deepsleep.py --help` *(fails: missing dependency numpy in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916745c6ad08331be723562733f39d6)